### PR TITLE
Add favicon to gouru website

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Gouru</title>
+  <link rel="icon" type="image/png" href="logos/gouru_logo_png.png" />
   <style>
     @font-face {
       font-family: 'Neue Montreal';


### PR DESCRIPTION
## Summary
- display the Gouru logo as the site's favicon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6862e4844eac8327b7c77d8e76ca8cfd