### PR TITLE
Add footer to Gouru site

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,6 +218,49 @@ nav {
     margin-right: 10px;
   }
 }
+
+/* footer styles */
+.site-footer {
+  background: #f5f5f5;
+  padding: 40px 20px;
+  font-size: 0.9rem;
+}
+.footer-top {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 40px;
+}
+.footer-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: bold;
+}
+.footer-logo-text {
+  font-size: 2rem;
+}
+.footer-section h3 {
+  margin: 0 0 10px 0;
+  font-size: 1rem;
+}
+.footer-section ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.footer-section li {
+  margin-bottom: 6px;
+}
+.site-footer a {
+  color: inherit;
+  text-decoration: none;
+}
+.footer-bottom {
+  text-align: center;
+  margin-top: 30px;
+  font-size: 0.8rem;
+}
   </style>
 </head>
 <body>
@@ -251,7 +294,38 @@ nav {
     </div>
   </div>
 
-  <div class="copyright">&copy; 2025 Gouru. All Rights Reserved.</div>
+  <footer class="site-footer">
+    <div class="footer-top">
+      <div class="footer-left">
+        <img src="logos/gouru_logo_png.png" alt="Gouru logo" class="logo-img" />
+        <span class="footer-logo-text">Gouru</span>
+      </div>
+      <div class="footer-section">
+        <h3>Past Works</h3>
+        <ul>
+          <li><a href="#">Project One</a></li>
+          <li><a href="#">Project Two</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Policies</h3>
+        <ul>
+          <li><a href="#">Ethics Policies</a></li>
+          <li><a href="#">Privacy Policy</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Reporting</h3>
+        <ul>
+          <li><a href="#">Brand Kit</a></li>
+          <li><a href="#">News &amp; Media</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      &copy; 2025 Gouru. All Rights Reserved. <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a>
+    </div>
+  </footer>
   <script>
     const hamburger = document.querySelector('.hamburger');
     const navLinks = document.querySelector('.nav-links');


### PR DESCRIPTION
## Summary
- redesign site footer to include logo, sections for works, policies and reporting
- show copyright along with links to gouru.org and gouru.foundation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686464ffbd1c83279c81c3a8e9e3d2f3