### PR TITLE
Fix expanding section smooth scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,16 +184,6 @@ nav {
       border-radius: 0;
     }
 
-    .expand-section.hold {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100vh;
-      margin: 0;
-      border-radius: 0;
-      z-index: 1001;
-    }
 
 @media (max-width: 600px) {
   .nav-links {
@@ -348,20 +338,12 @@ nav {
     const expandWrapper = document.querySelector('.expand-wrapper');
     const expandSection = document.querySelector('.expand-section');
 
-    let holdTimeout;
     function checkExpand() {
       const rect = expandWrapper.getBoundingClientRect();
-      if (rect.top <= 0 && rect.bottom >= window.innerHeight) {
-        clearTimeout(holdTimeout);
+      if (rect.top < window.innerHeight && rect.bottom > 0) {
         expandSection.classList.add('full');
       } else {
-        if (expandSection.classList.contains('full') && !expandSection.classList.contains('hold')) {
-          expandSection.classList.add('hold');
-          holdTimeout = setTimeout(() => {
-            expandSection.classList.remove('full');
-            expandSection.classList.remove('hold');
-          }, 1000);
-        }
+        expandSection.classList.remove('full');
       }
     }
 


### PR DESCRIPTION
## Summary
- remove sticky hold behavior from expanding section
- simplify scroll logic so it expands when in view and collapses when out

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686577e915d88327a502d170e70f9deb