### PR TITLE
Update footer layout and add attribution

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -350,7 +350,14 @@
   width: 100%;
   border: none;
   border-top: 1px solid rgba(0,0,0,0.2);
+  margin: 10px 0;
+}
+.footer-copy {
   margin: 0;
+  font-size: 0.8rem;
+}
+.footer-attribution {
+  font-size: 0.7rem;
 }
 .social-icons {
   display: flex;
@@ -526,11 +533,15 @@
           <img src="logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img" />
           <span class="footer-logo-text">Gouru</span>
         </div>
+        <p class="footer-copy">&copy; 2025 Gouru. All Rights Reserved.</p>
         <hr class="footer-divider" />
         <div class="social-icons">
           <a href="#"><img src="logos/linkedin.svg" alt="LinkedIn" /></a>
           <a href="#"><img src="logos/instagram.svg" alt="Instagram" /></a>
           <a href="#"><img src="logos/facebook.svg" alt="Facebook" /></a>
+        </div>
+        <div class="footer-attribution">
+          <a href="https://www.vecteezy.com/free-photos/night" rel="nofollow">Night Stock photos by Vecteezy</a>
         </div>
       </div>
       <div class="footer-section">
@@ -566,7 +577,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      &copy; 2025 Gouru. All Rights Reserved. <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a>
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a>
     </div>
   </footer>
   <script>

--- a/index.html
+++ b/index.html
@@ -420,7 +420,14 @@
   width: 100%;
   border: none;
   border-top: 1px solid rgba(0,0,0,0.2);
+  margin: 10px 0;
+}
+.footer-copy {
   margin: 0;
+  font-size: 0.8rem;
+}
+.footer-attribution {
+  font-size: 0.7rem;
 }
 .social-icons {
   display: flex;
@@ -631,11 +638,15 @@
           <img src="logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img" />
           <span class="footer-logo-text">Gouru</span>
         </div>
+        <p class="footer-copy">&copy; 2025 Gouru. All Rights Reserved.</p>
         <hr class="footer-divider" />
         <div class="social-icons">
           <a href="#"><img src="logos/linkedin.svg" alt="LinkedIn" /></a>
           <a href="#"><img src="logos/instagram.svg" alt="Instagram" /></a>
           <a href="#"><img src="logos/facebook.svg" alt="Facebook" /></a>
+        </div>
+        <div class="footer-attribution">
+          <a href="https://www.vecteezy.com/free-photos/night" rel="nofollow">Night Stock photos by Vecteezy</a>
         </div>
       </div>
       <div class="footer-section">
@@ -669,9 +680,6 @@
           <li><a href="#">News</a></li>
         </ul>
       </div>
-    </div>
-    <div class="footer-bottom">
-      &copy; 2025 Gouru. All Rights Reserved.
     </div>
   </footer>
   <script>

--- a/invest.html
+++ b/invest.html
@@ -350,7 +350,14 @@
   width: 100%;
   border: none;
   border-top: 1px solid rgba(0,0,0,0.2);
+  margin: 10px 0;
+}
+.footer-copy {
   margin: 0;
+  font-size: 0.8rem;
+}
+.footer-attribution {
+  font-size: 0.7rem;
 }
 .social-icons {
   display: flex;
@@ -526,11 +533,15 @@
           <img src="logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img" />
           <span class="footer-logo-text">Gouru</span>
         </div>
+        <p class="footer-copy">&copy; 2025 Gouru. All Rights Reserved.</p>
         <hr class="footer-divider" />
         <div class="social-icons">
           <a href="#"><img src="logos/linkedin.svg" alt="LinkedIn" /></a>
           <a href="#"><img src="logos/instagram.svg" alt="Instagram" /></a>
           <a href="#"><img src="logos/facebook.svg" alt="Facebook" /></a>
+        </div>
+        <div class="footer-attribution">
+          <a href="https://www.vecteezy.com/free-photos/night" rel="nofollow">Night Stock photos by Vecteezy</a>
         </div>
       </div>
       <div class="footer-section">
@@ -566,7 +577,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      &copy; 2025 Gouru. All Rights Reserved. <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a>
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a>
     </div>
   </footer>
   <script>

--- a/sell.html
+++ b/sell.html
@@ -350,7 +350,14 @@
   width: 100%;
   border: none;
   border-top: 1px solid rgba(0,0,0,0.2);
+  margin: 10px 0;
+}
+.footer-copy {
   margin: 0;
+  font-size: 0.8rem;
+}
+.footer-attribution {
+  font-size: 0.7rem;
 }
 .social-icons {
   display: flex;
@@ -526,11 +533,15 @@
           <img src="logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img" />
           <span class="footer-logo-text">Gouru</span>
         </div>
+        <p class="footer-copy">&copy; 2025 Gouru. All Rights Reserved.</p>
         <hr class="footer-divider" />
         <div class="social-icons">
           <a href="#"><img src="logos/linkedin.svg" alt="LinkedIn" /></a>
           <a href="#"><img src="logos/instagram.svg" alt="Instagram" /></a>
           <a href="#"><img src="logos/facebook.svg" alt="Facebook" /></a>
+        </div>
+        <div class="footer-attribution">
+          <a href="https://www.vecteezy.com/free-photos/night" rel="nofollow">Night Stock photos by Vecteezy</a>
         </div>
       </div>
       <div class="footer-section">
@@ -566,7 +577,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      &copy; 2025 Gouru. All Rights Reserved. <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a>
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a>
     </div>
   </footer>
   <script>

--- a/team.html
+++ b/team.html
@@ -350,7 +350,14 @@
   width: 100%;
   border: none;
   border-top: 1px solid rgba(0,0,0,0.2);
+  margin: 10px 0;
+}
+.footer-copy {
   margin: 0;
+  font-size: 0.8rem;
+}
+.footer-attribution {
+  font-size: 0.7rem;
 }
 .social-icons {
   display: flex;
@@ -526,11 +533,15 @@
           <img src="logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img" />
           <span class="footer-logo-text">Gouru</span>
         </div>
+        <p class="footer-copy">&copy; 2025 Gouru. All Rights Reserved.</p>
         <hr class="footer-divider" />
         <div class="social-icons">
           <a href="#"><img src="logos/linkedin.svg" alt="LinkedIn" /></a>
           <a href="#"><img src="logos/instagram.svg" alt="Instagram" /></a>
           <a href="#"><img src="logos/facebook.svg" alt="Facebook" /></a>
+        </div>
+        <div class="footer-attribution">
+          <a href="https://www.vecteezy.com/free-photos/night" rel="nofollow">Night Stock photos by Vecteezy</a>
         </div>
       </div>
       <div class="footer-section">
@@ -566,7 +577,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      &copy; 2025 Gouru. All Rights Reserved. <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a>
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a>
     </div>
   </footer>
   <script>


### PR DESCRIPTION
## Summary
- reposition copyright text above the footer divider
- add image attribution link with `rel="nofollow"`
- adjust footer styles for spacing
- keep site links in footer bottom

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68883b84d0648327a83582318a2440d5