### PR TITLE
Expand navbar dropdowns to fit content

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -182,10 +182,10 @@
   .dropdown-sections {
     display: flex;
     gap: 20px;
-    justify-content: space-between;
+    justify-content: flex-start;
   }
   .dropdown-col {
-    flex: 1;
+    flex: 0 0 auto;
     padding: 10px;
     border-right: 1px solid var(--color-neutral-light);
   }
@@ -202,6 +202,9 @@
   }
   .dropdown-col.image-col img {
     max-height: 60px;
+  }
+  .dropdown-content a {
+    white-space: nowrap;
   }
 
     .nav-left,

--- a/index.html
+++ b/index.html
@@ -215,10 +215,10 @@
   .dropdown-sections {
     display: flex;
     gap: 20px;
-    justify-content: space-between;
+    justify-content: flex-start;
   }
   .dropdown-col {
-    flex: 1;
+    flex: 0 0 auto;
     padding: 10px;
     border-right: 1px solid var(--color-neutral-light);
   }
@@ -235,6 +235,9 @@
   }
   .dropdown-col.image-col img {
     max-height: 60px;
+  }
+  .dropdown-content a {
+    white-space: nowrap;
   }
 
     .nav-left,

--- a/invest.html
+++ b/invest.html
@@ -182,10 +182,10 @@
   .dropdown-sections {
     display: flex;
     gap: 20px;
-    justify-content: space-between;
+    justify-content: flex-start;
   }
   .dropdown-col {
-    flex: 1;
+    flex: 0 0 auto;
     padding: 10px;
     border-right: 1px solid var(--color-neutral-light);
   }
@@ -202,6 +202,9 @@
   }
   .dropdown-col.image-col img {
     max-height: 60px;
+  }
+  .dropdown-content a {
+    white-space: nowrap;
   }
 
     .nav-left,

--- a/sell.html
+++ b/sell.html
@@ -182,10 +182,10 @@
   .dropdown-sections {
     display: flex;
     gap: 20px;
-    justify-content: space-between;
+    justify-content: flex-start;
   }
   .dropdown-col {
-    flex: 1;
+    flex: 0 0 auto;
     padding: 10px;
     border-right: 1px solid var(--color-neutral-light);
   }
@@ -202,6 +202,9 @@
   }
   .dropdown-col.image-col img {
     max-height: 60px;
+  }
+  .dropdown-content a {
+    white-space: nowrap;
   }
 
     .nav-left,

--- a/team.html
+++ b/team.html
@@ -182,10 +182,10 @@
   .dropdown-sections {
     display: flex;
     gap: 20px;
-    justify-content: space-between;
+    justify-content: flex-start;
   }
   .dropdown-col {
-    flex: 1;
+    flex: 0 0 auto;
     padding: 10px;
     border-right: 1px solid var(--color-neutral-light);
   }
@@ -202,6 +202,9 @@
   }
   .dropdown-col.image-col img {
     max-height: 60px;
+  }
+  .dropdown-content a {
+    white-space: nowrap;
   }
 
     .nav-left,


### PR DESCRIPTION
## Summary
- Let navbar dropdown columns size to their content instead of fixed thirds
- Prevent dropdown links from wrapping to keep options on a single line

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688d8290788c832784d85341f2ed8eb7