### PR TITLE
Add privacy policy and terms of service pages

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -514,6 +514,8 @@
           </div>
         </div>
       </li>
+      <li><a href="privacy.html">Privacy</a></li>
+      <li><a href="terms.html">Terms</a></li>
     </ul>
     <button class="nav-right" id="investor-portal-btn">Investor Portal</button>
   </nav>
@@ -589,7 +591,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a>
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="terms.html">Terms of Service</a> | <a href="privacy.html">Privacy Policy</a>
     </div>
   </footer>
   <script>

--- a/index.html
+++ b/index.html
@@ -587,6 +587,8 @@
           </div>
         </div>
       </li>
+      <li><a href="privacy.html">Privacy</a></li>
+      <li><a href="terms.html">Terms</a></li>
     </ul>
     <button class="nav-right" id="investor-portal-btn">Investor Portal</button>
   </nav>
@@ -692,6 +694,9 @@
           <li><a href="#">News</a></li>
         </ul>
       </div>
+    </div>
+    <div class="footer-bottom">
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="terms.html">Terms of Service</a> | <a href="privacy.html">Privacy Policy</a>
     </div>
   </footer>
   <script>

--- a/invest.html
+++ b/invest.html
@@ -514,6 +514,8 @@
           </div>
         </div>
       </li>
+      <li><a href="privacy.html">Privacy</a></li>
+      <li><a href="terms.html">Terms</a></li>
     </ul>
     <button class="nav-right" id="investor-portal-btn">Investor Portal</button>
   </nav>
@@ -589,7 +591,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a>
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="terms.html">Terms of Service</a> | <a href="privacy.html">Privacy Policy</a>
     </div>
   </footer>
   <script>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,675 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Privacy Policy - Gouru</title>
+  <link rel="icon" type="image/png" href="logos/gouru_logo_png-favicon.png" />
+  <style>
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-Light.otf') format('opentype');
+      font-weight: 300;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-LightItalic.otf') format('opentype');
+      font-weight: 300;
+      font-style: italic;
+    }
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-Regular.otf') format('opentype');
+      font-weight: 400;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-Italic.otf') format('opentype');
+      font-weight: 400;
+      font-style: italic;
+    }
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-Medium.otf') format('opentype');
+      font-weight: 500;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-MediumItalic.otf') format('opentype');
+      font-weight: 500;
+      font-style: italic;
+    }
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-Bold.otf') format('opentype');
+      font-weight: 700;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-BoldItalic.otf') format('opentype');
+      font-weight: 700;
+      font-style: italic;
+    }
+    :root {
+      --color-primary: #0b3e5b;
+      --color-secondary: #2a9d8f;
+      --color-support: #febe5d;
+      --color-neutral-dark: #3a3a3a;
+      --color-neutral-light: #e8e8e8;
+      --color-alert: #f3535e;
+      --color-success: #748b75;
+      --color-surface: #ffffff;
+    }
+
+    html, body {
+      background: var(--color-surface);
+      color: var(--color-neutral-dark);
+      margin: 0;
+      min-height: 100%;
+      overflow-x: hidden;
+      font-family: 'Neue Montreal', Arial, sans-serif;
+      box-sizing: border-box;
+      font-size: 18px;
+    }
+    a {
+      color: var(--color-secondary);
+    }
+    a:hover {
+      color: var(--color-primary);
+    }
+
+    nav {
+      color: var(--color-primary);
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 20px;
+      box-sizing: border-box;
+      z-index: 1000;
+    }
+    .logo {
+      font-weight: bold;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .logo-img {
+      height: 48px;
+      width: auto;
+    }
+    .logo span {
+      font-size: 1.5rem;
+      letter-spacing: 2px;
+    }
+    .nav-links {
+      list-style: none;
+      display: flex;
+      gap: 12px;
+      margin: 0;
+      padding: 6px 14px;
+      background: rgba(255, 255, 255, 0.4);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      border: 1px solid rgba(255, 255, 255, 0.4);
+      border-radius: 999px;
+    }
+    .dropdown {
+      position: relative;
+    }
+    .dropdown-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      width: auto;
+      max-width: calc(100vw - 40px);
+      min-width: 220px;
+      border-radius: 10px;
+      background: rgba(255, 255, 255, 0.95);
+      padding: 20px;
+      display: none;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+      color: var(--color-primary);
+      z-index: 999;
+    }
+    .dropdown:hover .dropdown-content {
+      display: block;
+    }
+    .dropdown-sections {
+      display: flex;
+      gap: 20px;
+      justify-content: flex-start;
+    }
+    .dropdown-col {
+      flex: 0 0 auto;
+      padding: 10px;
+      border-right: 1px solid var(--color-neutral-light);
+    }
+    .dropdown-col:last-child {
+      border-right: none;
+    }
+    .dropdown-col h4 {
+      margin-top: 0;
+    }
+    .dropdown-col.image-col {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .dropdown-col.image-col img {
+      max-height: 60px;
+    }
+
+    .nav-left,
+    .nav-right {
+      background: rgba(255, 255, 255, 0.4);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      border-radius: 999px;
+      padding: 0 14px;
+      display: flex;
+      align-items: center;
+      height: 40px;
+    }
+    .nav-right {
+      position: relative;
+      cursor: pointer;
+      color: var(--color-primary);
+      border: 2px solid transparent;
+      overflow: hidden;
+    }
+    .nav-right::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      padding: 2px;
+      --angle: 0deg;
+      background: conic-gradient(from var(--angle), red, orange, yellow, green, blue, indigo, violet, red);
+      -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+      -webkit-mask-composite: xor;
+      mask-composite: exclude;
+      animation: slide 4s linear infinite;
+      pointer-events: none;
+    }
+    .nav-links a {
+      text-decoration: none;
+      color: var(--color-primary);
+      display: block;
+      padding: 6px 0;
+    }
+    .nav-links a:hover {
+      color: var(--color-secondary);
+    }
+    .hamburger,
+    .close-btn {
+      display: none;
+      font-size: 24px;
+      cursor: pointer;
+      background: none;
+      border: none;
+    }
+
+    .hero {
+      position: relative;
+      height: 45vh;
+      width: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      color: #fff;
+      background: linear-gradient(135deg, rgba(11, 62, 91, 0.9), rgba(42, 157, 143, 0.85)), url('sample-image') center/cover no-repeat;
+      margin-bottom: 40px;
+    }
+    .hero .hero-text {
+      max-width: 700px;
+      padding: 20px;
+    }
+    .hero h1 {
+      margin: 0;
+      font-size: 3rem;
+      letter-spacing: 1px;
+    }
+    .hero p {
+      font-size: 1.1rem;
+      margin-top: 10px;
+      opacity: 0.9;
+    }
+
+    .legal-content {
+      max-width: 900px;
+      margin: 0 auto 80px;
+      padding: 0 20px 40px;
+    }
+    .legal-section {
+      margin-bottom: 40px;
+    }
+    .legal-section h2 {
+      font-size: 1.8rem;
+      color: var(--color-primary);
+      margin-bottom: 12px;
+    }
+    .legal-section p,
+    .legal-section ul {
+      line-height: 1.6;
+    }
+    .legal-section ul {
+      padding-left: 20px;
+    }
+    .legal-section li {
+      margin-bottom: 10px;
+    }
+
+    .site-footer {
+      background: #0b3e5b;
+      color: #fff;
+      padding: 50px 20px;
+      position: relative;
+      overflow: hidden;
+    }
+    .footer-top {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 30px;
+      max-width: 1200px;
+      margin: 0 auto;
+      align-items: flex-start;
+    }
+    .footer-left {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+    .logo-group {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .footer-logo-text {
+      font-size: 1.4rem;
+      letter-spacing: 2px;
+    }
+    .footer-divider {
+      border: none;
+      height: 1px;
+      width: 100%;
+      background: rgba(255, 255, 255, 0.2);
+      margin: 10px 0;
+    }
+    .footer-copy {
+      margin: 0;
+      font-size: 0.9rem;
+    }
+    .social-icons {
+      display: flex;
+      gap: 12px;
+    }
+    .footer-section h3 {
+      margin-top: 0;
+      color: #fff;
+    }
+    .footer-section ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    .footer-section li {
+      margin-bottom: 6px;
+    }
+    .site-footer a {
+      color: var(--color-secondary);
+      text-decoration: none;
+    }
+    .site-footer a:hover {
+      color: var(--color-support);
+    }
+    @keyframes slide {
+      from { --angle: 0deg; }
+      to { --angle: 360deg; }
+    }
+    .footer-bottom {
+      text-align: center;
+      margin-top: 30px;
+      padding-top: 10px;
+      font-size: 0.8rem;
+      border-top: 1px solid rgba(255,255,255,0.2);
+      color: rgba(255,255,255,0.8);
+      max-width: 1200px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .popup {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.6);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      z-index: 2000;
+    }
+    .popup-content {
+      background: #fff;
+      padding: 20px 30px;
+      border-radius: 10px;
+      position: relative;
+      text-align: center;
+      max-width: 400px;
+      box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+    }
+    .popup-close {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background: none;
+      border: none;
+      font-size: 1.2rem;
+      cursor: pointer;
+    }
+
+    @media (max-width: 900px) {
+      .nav-links {
+        position: fixed;
+        top: 0;
+        right: 0;
+        height: 100%;
+        width: 280px;
+        background: rgba(255, 255, 255, 0.95);
+        flex-direction: column;
+        padding: 40px 20px;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
+        border-radius: 0;
+      }
+      .nav-links.open {
+        transform: translateX(0);
+      }
+      .nav-links li {
+        width: 100%;
+      }
+      .hamburger,
+      .close-btn {
+        display: block;
+      }
+      nav {
+        background: rgba(255, 255, 255, 0.9);
+        backdrop-filter: blur(10px);
+      }
+      .hero {
+        height: 55vh;
+      }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="logo"><img src="logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img"> <span>Gouru</span>
+    </div>
+    <button class="hamburger">&#9776;</button>
+    <ul class="nav-links">
+      <li class="close-btn">&times;</li>
+      <li class="dropdown">
+        <a href="invest.html">Invest With Us</a>
+        <div class="dropdown-content invest-menu">
+          <h3>Invest with us</h3>
+          <div class="dropdown-sections">
+            <div class="dropdown-col">
+              <h4>About Us</h4>
+              <a href="index.html">Our Portfolio</a>
+              <a href="team.html">Our Team</a>
+              <a href="careers.html">Careers</a>
+            </div>
+            <div class="dropdown-col">
+              <h4>Invest</h4>
+              <a href="invest.html">Investment Process</a>
+              <a href="#">Offerings</a>
+              <a href="#">FAQ</a>
+            </div>
+            <div class="dropdown-col image-col">
+              <img src="sample-image" alt="Sample" />
+            </div>
+          </div>
+        </div>
+      </li>
+      <li class="dropdown">
+        <a href="sell.html">Sell to Us</a>
+        <div class="dropdown-content sell-menu">
+          <h3>Sell to us</h3>
+          <div class="dropdown-sections">
+            <div class="dropdown-col">
+              <h4>Owners</h4>
+              <a href="sell.html">Selling Process</a>
+              <a href="#">Submit Property</a>
+              <a href="#">FAQ</a>
+            </div>
+            <div class="dropdown-col">
+              <h4>Agents</h4>
+              <a href="#">Commissions</a>
+              <a href="#">Partnerships</a>
+              <a href="#">Resources</a>
+            </div>
+            <div class="dropdown-col image-col">
+              <img src="sample-image" alt="Sample" />
+            </div>
+          </div>
+        </div>
+      </li>
+      <li class="dropdown">
+        <a href="#">About Us</a>
+        <div class="dropdown-content about-menu">
+          <h3>About Us</h3>
+          <div class="dropdown-sections">
+            <div class="dropdown-col">
+              <h4>About Us</h4>
+              <a href="team.html">Our Team</a>
+              <a href="careers.html">Careers</a>
+              <a href="#">Contact Us</a>
+            </div>
+            <div class="dropdown-col">
+              <h4>Mission</h4>
+              <p>To build communities through real estate innovation.</p>
+            </div>
+            <div class="dropdown-col image-col">
+              <img src="sample-image" alt="Sample" />
+            </div>
+          </div>
+        </div>
+      </li>
+      <li><a href="privacy.html">Privacy</a></li>
+      <li><a href="terms.html">Terms</a></li>
+    </ul>
+    <button class="nav-right" id="investor-portal-btn">Investor Portal</button>
+  </nav>
+
+  <section id="hero" class="hero">
+    <div class="hero-text">
+      <h1>Privacy Policy</h1>
+      <p>We respect your privacy and are committed to protecting your personal information.</p>
+    </div>
+  </section>
+
+  <main class="legal-content">
+    <div class="legal-section">
+      <h2>1. Introduction</h2>
+      <p>This Privacy Policy describes how Gouru (“Gouru,” “we,” “us,” or “our”) collects, uses, and shares information when you interact with our websites, products, and services (collectively, the “Services”). It also explains the choices you have with respect to your personal information.</p>
+    </div>
+    <div class="legal-section">
+      <h2>2. Information We Collect</h2>
+      <p>We collect information that you voluntarily provide to us and data that is automatically collected when you interact with our Services.</p>
+      <ul>
+        <li><strong>Account and contact information:</strong> such as your name, email address, phone number, and company details when you request more information or engage with us.</li>
+        <li><strong>Transaction and communications records:</strong> including the content of your messages, agreements, and any documents shared with us.</li>
+        <li><strong>Usage data:</strong> such as log files, device identifiers, browser type, IP address, pages visited, and referring/exit pages collected through cookies and similar technologies.</li>
+      </ul>
+    </div>
+    <div class="legal-section">
+      <h2>3. How We Use Information</h2>
+      <p>We use the information we collect to:</p>
+      <ul>
+        <li>Provide, maintain, and improve our Services;</li>
+        <li>Respond to inquiries, process transactions, and fulfill contractual obligations;</li>
+        <li>Communicate about updates, new offerings, and promotional content (you may opt out at any time);</li>
+        <li>Personalize your experience and analyze how our Services are used;</li>
+        <li>Detect, prevent, and address fraud, security, or technical issues; and</li>
+        <li>Comply with legal and regulatory requirements.</li>
+      </ul>
+    </div>
+    <div class="legal-section">
+      <h2>4. Sharing of Information</h2>
+      <p>We do not sell your personal information. We may share it with trusted parties under the following circumstances:</p>
+      <ul>
+        <li><strong>Service providers:</strong> with vendors who perform services on our behalf, such as analytics, hosting, and marketing support.</li>
+        <li><strong>Business partners:</strong> when collaborating on transactions, co-branded offerings, or joint marketing activities.</li>
+        <li><strong>Legal compliance:</strong> if required to do so by law, regulation, or legal process, or to protect the rights, property, or safety of Gouru, our clients, or the public.</li>
+        <li><strong>Corporate transactions:</strong> in connection with any merger, sale of company assets, financing, or acquisition of all or a portion of our business.</li>
+      </ul>
+    </div>
+    <div class="legal-section">
+      <h2>5. Cookies and Similar Technologies</h2>
+      <p>We use cookies, web beacons, and similar technologies to understand how our Services are used, remember your preferences, and improve performance. You can adjust your browser settings to refuse cookies; however, doing so may limit your ability to use certain features.</p>
+    </div>
+    <div class="legal-section">
+      <h2>6. Data Security</h2>
+      <p>We maintain administrative, technical, and physical safeguards designed to protect your personal information against accidental or unlawful destruction, loss, alteration, unauthorized disclosure, or access. While we strive to protect your information, no method of transmission or storage is completely secure.</p>
+    </div>
+    <div class="legal-section">
+      <h2>7. Your Choices and Rights</h2>
+      <p>You may update your contact details, request access to the information we hold about you, or ask us to delete it by contacting us using the details below. Depending on your jurisdiction, you may have additional rights under applicable privacy laws.</p>
+    </div>
+    <div class="legal-section">
+      <h2>8. International Data Transfers</h2>
+      <p>Gouru operates in multiple jurisdictions. When we transfer personal information outside of your country, we ensure appropriate safeguards are in place in accordance with applicable law.</p>
+    </div>
+    <div class="legal-section">
+      <h2>9. Children’s Privacy</h2>
+      <p>Our Services are not directed to children under the age of 13, and we do not knowingly collect personal information from children. If we become aware that a child has provided us with personal information, we will take steps to delete such information.</p>
+    </div>
+    <div class="legal-section">
+      <h2>10. Changes to This Policy</h2>
+      <p>We may update this Privacy Policy from time to time. When we do, we will revise the “Last Updated” date below. Your continued use of the Services following any changes signifies your acceptance of the updated policy.</p>
+    </div>
+    <div class="legal-section">
+      <h2>11. Contact Us</h2>
+      <p>If you have questions about this Privacy Policy or our data practices, please contact us at <a href="mailto:privacy@gouru.com">privacy@gouru.com</a>.</p>
+      <p><em>Last Updated: March 2025</em></p>
+    </div>
+  </main>
+
+  <div id="investor-portal-popup" class="popup" style="display:none;">
+    <div class="popup-content">
+      <button class="popup-close">&times;</button>
+      <p>Investor Portal will be launched soon</p>
+    </div>
+  </div>
+
+  <footer class="site-footer">
+    <div class="footer-top">
+      <div class="footer-left">
+        <div class="logo-group">
+          <img src="logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img" />
+          <span class="footer-logo-text">Gouru</span>
+        </div>
+        <p class="footer-copy">&copy; 2025 Gouru. All Rights Reserved.</p>
+        <hr class="footer-divider" />
+        <div class="social-icons">
+          <a href="https://linkedin.com/company/gouru"><img src="logos/linkedin.svg" alt="LinkedIn" /></a>
+          <a href="#"><img src="logos/instagram.svg" alt="Instagram" /></a>
+          <a href="#"><img src="logos/facebook.svg" alt="Facebook" /></a>
+        </div>
+        <div class="footer-attribution">
+          <a href="https://www.vecteezy.com/free-photos/night" rel="nofollow">Night Stock photos by Vecteezy</a>
+        </div>
+      </div>
+      <div class="footer-section">
+        <h3>Investors</h3>
+        <ul>
+          <li><a href="#">Investment Process</a></li>
+          <li><a href="#">Offerings</a></li>
+          <li><a href="#">Our Portfolio</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Sellers</h3>
+        <ul>
+          <li><a href="#">Selling Process</a></li>
+          <li><a href="#">Owners</a></li>
+          <li><a href="#">Brokers</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>About Us</h3>
+        <ul>
+          <li><a href="team.html">Our Team</a></li>
+          <li><a href="careers.html">Careers</a></li>
+          <li><a href="#">Contact Us</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>News and Reporting</h3>
+        <ul>
+          <li><a href="#">Brand Kit</a></li>
+          <li><a href="#">News</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="terms.html">Terms of Service</a> | <a href="privacy.html">Privacy Policy</a>
+    </div>
+  </footer>
+
+  <script>
+    const hamburger = document.querySelector('.hamburger');
+    const navLinks = document.querySelector('.nav-links');
+    const closeBtn = document.querySelector('.close-btn');
+    const portalBtn = document.getElementById('investor-portal-btn');
+    const portalPopup = document.getElementById('investor-portal-popup');
+    const popupClose = document.querySelector('.popup-close');
+    const hero = document.getElementById('hero');
+
+    hamburger.addEventListener('click', () => {
+      navLinks.classList.add('open');
+    });
+    closeBtn.addEventListener('click', () => {
+      navLinks.classList.remove('open');
+    });
+
+    if (portalBtn) {
+      portalBtn.addEventListener('click', () => {
+        if (portalPopup) {
+          portalPopup.style.display = 'flex';
+        }
+      });
+    }
+    if (popupClose) {
+      popupClose.addEventListener('click', () => {
+        if (portalPopup) {
+          portalPopup.style.display = 'none';
+        }
+      });
+    }
+
+    function checkHero() {
+      if (!hero) return;
+      if (window.scrollY > 50) {
+        hero.classList.add('shrink');
+      } else {
+        hero.classList.remove('shrink');
+      }
+    }
+
+    document.addEventListener('scroll', checkHero);
+    checkHero();
+  </script>
+</body>
+</html>

--- a/sell.html
+++ b/sell.html
@@ -514,6 +514,8 @@
           </div>
         </div>
       </li>
+      <li><a href="privacy.html">Privacy</a></li>
+      <li><a href="terms.html">Terms</a></li>
     </ul>
     <button class="nav-right" id="investor-portal-btn">Investor Portal</button>
   </nav>
@@ -589,7 +591,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a>
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="terms.html">Terms of Service</a> | <a href="privacy.html">Privacy Policy</a>
     </div>
   </footer>
   <script>

--- a/team.html
+++ b/team.html
@@ -514,6 +514,8 @@
           </div>
         </div>
       </li>
+      <li><a href="privacy.html">Privacy</a></li>
+      <li><a href="terms.html">Terms</a></li>
     </ul>
     <button class="nav-right" id="investor-portal-btn">Investor Portal</button>
   </nav>
@@ -589,7 +591,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a>
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="terms.html">Terms of Service</a> | <a href="privacy.html">Privacy Policy</a>
     </div>
   </footer>
   <script>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,683 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Terms of Service - Gouru</title>
+  <link rel="icon" type="image/png" href="logos/gouru_logo_png-favicon.png" />
+  <style>
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-Light.otf') format('opentype');
+      font-weight: 300;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-LightItalic.otf') format('opentype');
+      font-weight: 300;
+      font-style: italic;
+    }
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-Regular.otf') format('opentype');
+      font-weight: 400;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-Italic.otf') format('opentype');
+      font-weight: 400;
+      font-style: italic;
+    }
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-Medium.otf') format('opentype');
+      font-weight: 500;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-MediumItalic.otf') format('opentype');
+      font-weight: 500;
+      font-style: italic;
+    }
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-Bold.otf') format('opentype');
+      font-weight: 700;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'Neue Montreal';
+      src: url('fonts/NeueMontreal-BoldItalic.otf') format('opentype');
+      font-weight: 700;
+      font-style: italic;
+    }
+    :root {
+      --color-primary: #0b3e5b;
+      --color-secondary: #2a9d8f;
+      --color-support: #febe5d;
+      --color-neutral-dark: #3a3a3a;
+      --color-neutral-light: #e8e8e8;
+      --color-alert: #f3535e;
+      --color-success: #748b75;
+      --color-surface: #ffffff;
+    }
+
+    html, body {
+      background: var(--color-surface);
+      color: var(--color-neutral-dark);
+      margin: 0;
+      min-height: 100%;
+      overflow-x: hidden;
+      font-family: 'Neue Montreal', Arial, sans-serif;
+      box-sizing: border-box;
+      font-size: 18px;
+    }
+    a {
+      color: var(--color-secondary);
+    }
+    a:hover {
+      color: var(--color-primary);
+    }
+
+    nav {
+      color: var(--color-primary);
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 20px;
+      box-sizing: border-box;
+      z-index: 1000;
+    }
+    .logo {
+      font-weight: bold;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .logo-img {
+      height: 48px;
+      width: auto;
+    }
+    .logo span {
+      font-size: 1.5rem;
+      letter-spacing: 2px;
+    }
+    .nav-links {
+      list-style: none;
+      display: flex;
+      gap: 12px;
+      margin: 0;
+      padding: 6px 14px;
+      background: rgba(255, 255, 255, 0.4);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      border: 1px solid rgba(255, 255, 255, 0.4);
+      border-radius: 999px;
+    }
+    .dropdown {
+      position: relative;
+    }
+    .dropdown-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      width: auto;
+      max-width: calc(100vw - 40px);
+      min-width: 220px;
+      border-radius: 10px;
+      background: rgba(255, 255, 255, 0.95);
+      padding: 20px;
+      display: none;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+      color: var(--color-primary);
+      z-index: 999;
+    }
+    .dropdown:hover .dropdown-content {
+      display: block;
+    }
+    .dropdown-sections {
+      display: flex;
+      gap: 20px;
+      justify-content: flex-start;
+    }
+    .dropdown-col {
+      flex: 0 0 auto;
+      padding: 10px;
+      border-right: 1px solid var(--color-neutral-light);
+    }
+    .dropdown-col:last-child {
+      border-right: none;
+    }
+    .dropdown-col h4 {
+      margin-top: 0;
+    }
+    .dropdown-col.image-col {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .dropdown-col.image-col img {
+      max-height: 60px;
+    }
+
+    .nav-left,
+    .nav-right {
+      background: rgba(255, 255, 255, 0.4);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      border-radius: 999px;
+      padding: 0 14px;
+      display: flex;
+      align-items: center;
+      height: 40px;
+    }
+    .nav-right {
+      position: relative;
+      cursor: pointer;
+      color: var(--color-primary);
+      border: 2px solid transparent;
+      overflow: hidden;
+    }
+    .nav-right::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      padding: 2px;
+      --angle: 0deg;
+      background: conic-gradient(from var(--angle), red, orange, yellow, green, blue, indigo, violet, red);
+      -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+      -webkit-mask-composite: xor;
+      mask-composite: exclude;
+      animation: slide 4s linear infinite;
+      pointer-events: none;
+    }
+    .nav-links a {
+      text-decoration: none;
+      color: var(--color-primary);
+      display: block;
+      padding: 6px 0;
+    }
+    .nav-links a:hover {
+      color: var(--color-secondary);
+    }
+    .hamburger,
+    .close-btn {
+      display: none;
+      font-size: 24px;
+      cursor: pointer;
+      background: none;
+      border: none;
+    }
+
+    .hero {
+      position: relative;
+      height: 45vh;
+      width: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      color: #fff;
+      background: linear-gradient(135deg, rgba(11, 62, 91, 0.92), rgba(116, 139, 117, 0.85)), url('sample-image') center/cover no-repeat;
+      margin-bottom: 40px;
+    }
+    .hero .hero-text {
+      max-width: 700px;
+      padding: 20px;
+    }
+    .hero h1 {
+      margin: 0;
+      font-size: 3rem;
+      letter-spacing: 1px;
+    }
+    .hero p {
+      font-size: 1.1rem;
+      margin-top: 10px;
+      opacity: 0.9;
+    }
+
+    .legal-content {
+      max-width: 900px;
+      margin: 0 auto 80px;
+      padding: 0 20px 40px;
+    }
+    .legal-section {
+      margin-bottom: 40px;
+    }
+    .legal-section h2 {
+      font-size: 1.8rem;
+      color: var(--color-primary);
+      margin-bottom: 12px;
+    }
+    .legal-section p,
+    .legal-section ul {
+      line-height: 1.6;
+    }
+    .legal-section ul {
+      padding-left: 20px;
+    }
+    .legal-section li {
+      margin-bottom: 10px;
+    }
+
+    .site-footer {
+      background: #0b3e5b;
+      color: #fff;
+      padding: 50px 20px;
+      position: relative;
+      overflow: hidden;
+    }
+    .footer-top {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 30px;
+      max-width: 1200px;
+      margin: 0 auto;
+      align-items: flex-start;
+    }
+    .footer-left {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+    .logo-group {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .footer-logo-text {
+      font-size: 1.4rem;
+      letter-spacing: 2px;
+    }
+    .footer-divider {
+      border: none;
+      height: 1px;
+      width: 100%;
+      background: rgba(255, 255, 255, 0.2);
+      margin: 10px 0;
+    }
+    .footer-copy {
+      margin: 0;
+      font-size: 0.9rem;
+    }
+    .social-icons {
+      display: flex;
+      gap: 12px;
+    }
+    .footer-section h3 {
+      margin-top: 0;
+      color: #fff;
+    }
+    .footer-section ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    .footer-section li {
+      margin-bottom: 6px;
+    }
+    .site-footer a {
+      color: var(--color-secondary);
+      text-decoration: none;
+    }
+    .site-footer a:hover {
+      color: var(--color-support);
+    }
+    @keyframes slide {
+      from { --angle: 0deg; }
+      to { --angle: 360deg; }
+    }
+    .footer-bottom {
+      text-align: center;
+      margin-top: 30px;
+      padding-top: 10px;
+      font-size: 0.8rem;
+      border-top: 1px solid rgba(255,255,255,0.2);
+      color: rgba(255,255,255,0.8);
+      max-width: 1200px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .popup {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.6);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      z-index: 2000;
+    }
+    .popup-content {
+      background: #fff;
+      padding: 20px 30px;
+      border-radius: 10px;
+      position: relative;
+      text-align: center;
+      max-width: 400px;
+      box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+    }
+    .popup-close {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background: none;
+      border: none;
+      font-size: 1.2rem;
+      cursor: pointer;
+    }
+
+    @media (max-width: 900px) {
+      .nav-links {
+        position: fixed;
+        top: 0;
+        right: 0;
+        height: 100%;
+        width: 280px;
+        background: rgba(255, 255, 255, 0.95);
+        flex-direction: column;
+        padding: 40px 20px;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
+        border-radius: 0;
+      }
+      .nav-links.open {
+        transform: translateX(0);
+      }
+      .nav-links li {
+        width: 100%;
+      }
+      .hamburger,
+      .close-btn {
+        display: block;
+      }
+      nav {
+        background: rgba(255, 255, 255, 0.9);
+        backdrop-filter: blur(10px);
+      }
+      .hero {
+        height: 55vh;
+      }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="logo"><img src="logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img"> <span>Gouru</span>
+    </div>
+    <button class="hamburger">&#9776;</button>
+    <ul class="nav-links">
+      <li class="close-btn">&times;</li>
+      <li class="dropdown">
+        <a href="invest.html">Invest With Us</a>
+        <div class="dropdown-content invest-menu">
+          <h3>Invest with us</h3>
+          <div class="dropdown-sections">
+            <div class="dropdown-col">
+              <h4>About Us</h4>
+              <a href="index.html">Our Portfolio</a>
+              <a href="team.html">Our Team</a>
+              <a href="careers.html">Careers</a>
+            </div>
+            <div class="dropdown-col">
+              <h4>Invest</h4>
+              <a href="invest.html">Investment Process</a>
+              <a href="#">Offerings</a>
+              <a href="#">FAQ</a>
+            </div>
+            <div class="dropdown-col image-col">
+              <img src="sample-image" alt="Sample" />
+            </div>
+          </div>
+        </div>
+      </li>
+      <li class="dropdown">
+        <a href="sell.html">Sell to Us</a>
+        <div class="dropdown-content sell-menu">
+          <h3>Sell to us</h3>
+          <div class="dropdown-sections">
+            <div class="dropdown-col">
+              <h4>Owners</h4>
+              <a href="sell.html">Selling Process</a>
+              <a href="#">Submit Property</a>
+              <a href="#">FAQ</a>
+            </div>
+            <div class="dropdown-col">
+              <h4>Agents</h4>
+              <a href="#">Commissions</a>
+              <a href="#">Partnerships</a>
+              <a href="#">Resources</a>
+            </div>
+            <div class="dropdown-col image-col">
+              <img src="sample-image" alt="Sample" />
+            </div>
+          </div>
+        </div>
+      </li>
+      <li class="dropdown">
+        <a href="#">About Us</a>
+        <div class="dropdown-content about-menu">
+          <h3>About Us</h3>
+          <div class="dropdown-sections">
+            <div class="dropdown-col">
+              <h4>About Us</h4>
+              <a href="team.html">Our Team</a>
+              <a href="careers.html">Careers</a>
+              <a href="#">Contact Us</a>
+            </div>
+            <div class="dropdown-col">
+              <h4>Mission</h4>
+              <p>To build communities through real estate innovation.</p>
+            </div>
+            <div class="dropdown-col image-col">
+              <img src="sample-image" alt="Sample" />
+            </div>
+          </div>
+        </div>
+      </li>
+      <li><a href="privacy.html">Privacy</a></li>
+      <li><a href="terms.html">Terms</a></li>
+    </ul>
+    <button class="nav-right" id="investor-portal-btn">Investor Portal</button>
+  </nav>
+
+  <section id="hero" class="hero">
+    <div class="hero-text">
+      <h1>Terms of Service</h1>
+      <p>These terms govern your access to and use of Gouru’s services, products, and digital properties.</p>
+    </div>
+  </section>
+
+  <main class="legal-content">
+    <div class="legal-section">
+      <h2>1. Acceptance of Terms</h2>
+      <p>By accessing or using the Services provided by Gouru, you agree to be bound by these Terms of Service (“Terms”) and our Privacy Policy. If you do not agree, you must discontinue use immediately.</p>
+    </div>
+    <div class="legal-section">
+      <h2>2. Services</h2>
+      <p>Gouru provides real estate investment, acquisition, and advisory services to owners, investors, and partners. Specific products or transactions may require additional agreements that supplement these Terms.</p>
+    </div>
+    <div class="legal-section">
+      <h2>3. Eligibility</h2>
+      <p>You represent and warrant that you are at least 18 years of age and have the legal authority to enter into these Terms. You are responsible for complying with all laws and regulations applicable to your use of the Services.</p>
+    </div>
+    <div class="legal-section">
+      <h2>4. Accounts and Communications</h2>
+      <p>Some Services may require creating an account or sharing information with us. You agree to provide accurate, current, and complete information and to promptly update it as needed. You consent to receive communications from us electronically and agree that all notices satisfy legal requirements.</p>
+    </div>
+    <div class="legal-section">
+      <h2>5. Investment and Transaction Disclaimers</h2>
+      <p>Nothing presented through the Services constitutes an offer to sell or a solicitation of an offer to buy securities. Any investment decisions are made solely at your discretion and risk. Past performance is not indicative of future results.</p>
+    </div>
+    <div class="legal-section">
+      <h2>6. Seller and Partner Obligations</h2>
+      <p>If you engage with Gouru to sell property or participate as a partner, you agree to provide accurate information, disclose any material facts, and comply with all contractual commitments. Failure to do so may result in termination of the relationship and potential legal remedies.</p>
+    </div>
+    <div class="legal-section">
+      <h2>7. Intellectual Property</h2>
+      <p>All content, trademarks, logos, and other materials provided through the Services are owned by Gouru or its licensors and are protected by intellectual property laws. You may not copy, distribute, modify, or create derivative works without our prior written consent.</p>
+    </div>
+    <div class="legal-section">
+      <h2>8. Prohibited Conduct</h2>
+      <p>You agree not to:</p>
+      <ul>
+        <li>Use the Services in any manner that violates laws or regulations;</li>
+        <li>Interfere with or disrupt the integrity, security, or performance of the Services;</li>
+        <li>Attempt to gain unauthorized access to any portion of the Services or systems;</li>
+        <li>Transmit malicious code, spam, or other harmful content; or</li>
+        <li>Misrepresent your affiliation with any person or entity.</li>
+      </ul>
+    </div>
+    <div class="legal-section">
+      <h2>9. Third-Party Content and Links</h2>
+      <p>The Services may include links to third-party websites or resources. Gouru does not endorse and is not responsible for any third-party content, products, or services. Your use of third-party resources is at your own risk.</p>
+    </div>
+    <div class="legal-section">
+      <h2>10. Disclaimer of Warranties</h2>
+      <p>The Services are provided “as is” and “as available” without warranties of any kind, express or implied, including but not limited to warranties of merchantability, fitness for a particular purpose, and non-infringement.</p>
+    </div>
+    <div class="legal-section">
+      <h2>11. Limitation of Liability</h2>
+      <p>To the maximum extent permitted by law, Gouru and its affiliates will not be liable for indirect, incidental, consequential, or punitive damages, or for any loss of profits or revenues arising out of your use of the Services.</p>
+    </div>
+    <div class="legal-section">
+      <h2>12. Indemnification</h2>
+      <p>You agree to indemnify and hold harmless Gouru, its affiliates, and their respective officers, directors, employees, and agents from any claims, losses, damages, liabilities, and expenses arising from your use of the Services or violation of these Terms.</p>
+    </div>
+    <div class="legal-section">
+      <h2>13. Governing Law and Dispute Resolution</h2>
+      <p>These Terms are governed by the laws of the State of Delaware without regard to its conflict of laws principles. Any disputes will be resolved in the state or federal courts located in Delaware, and you consent to the jurisdiction of such courts.</p>
+    </div>
+    <div class="legal-section">
+      <h2>14. Changes to the Terms</h2>
+      <p>We may update these Terms from time to time. If we make material changes, we will provide notice via the Services or by other reasonable means. Your continued use of the Services after any update constitutes acceptance of the revised Terms.</p>
+    </div>
+    <div class="legal-section">
+      <h2>15. Termination</h2>
+      <p>We may suspend or terminate your access to the Services at any time for any reason, including if we believe you have violated these Terms. You may discontinue using the Services at any time.</p>
+    </div>
+    <div class="legal-section">
+      <h2>16. Contact Information</h2>
+      <p>If you have any questions about these Terms, please contact us at <a href="mailto:legal@gouru.com">legal@gouru.com</a>.</p>
+      <p><em>Last Updated: March 2025</em></p>
+    </div>
+  </main>
+
+  <div id="investor-portal-popup" class="popup" style="display:none;">
+    <div class="popup-content">
+      <button class="popup-close">&times;</button>
+      <p>Investor Portal will be launched soon</p>
+    </div>
+  </div>
+
+  <footer class="site-footer">
+    <div class="footer-top">
+      <div class="footer-left">
+        <div class="logo-group">
+          <img src="logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img" />
+          <span class="footer-logo-text">Gouru</span>
+        </div>
+        <p class="footer-copy">&copy; 2025 Gouru. All Rights Reserved.</p>
+        <hr class="footer-divider" />
+        <div class="social-icons">
+          <a href="https://linkedin.com/company/gouru"><img src="logos/linkedin.svg" alt="LinkedIn" /></a>
+          <a href="#"><img src="logos/instagram.svg" alt="Instagram" /></a>
+          <a href="#"><img src="logos/facebook.svg" alt="Facebook" /></a>
+        </div>
+        <div class="footer-attribution">
+          <a href="https://www.vecteezy.com/free-photos/night" rel="nofollow">Night Stock photos by Vecteezy</a>
+        </div>
+      </div>
+      <div class="footer-section">
+        <h3>Investors</h3>
+        <ul>
+          <li><a href="#">Investment Process</a></li>
+          <li><a href="#">Offerings</a></li>
+          <li><a href="#">Our Portfolio</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Sellers</h3>
+        <ul>
+          <li><a href="#">Selling Process</a></li>
+          <li><a href="#">Owners</a></li>
+          <li><a href="#">Brokers</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>About Us</h3>
+        <ul>
+          <li><a href="team.html">Our Team</a></li>
+          <li><a href="careers.html">Careers</a></li>
+          <li><a href="#">Contact Us</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>News and Reporting</h3>
+        <ul>
+          <li><a href="#">Brand Kit</a></li>
+          <li><a href="#">News</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="terms.html">Terms of Service</a> | <a href="privacy.html">Privacy Policy</a>
+    </div>
+  </footer>
+
+  <script>
+    const hamburger = document.querySelector('.hamburger');
+    const navLinks = document.querySelector('.nav-links');
+    const closeBtn = document.querySelector('.close-btn');
+    const portalBtn = document.getElementById('investor-portal-btn');
+    const portalPopup = document.getElementById('investor-portal-popup');
+    const popupClose = document.querySelector('.popup-close');
+    const hero = document.getElementById('hero');
+
+    hamburger.addEventListener('click', () => {
+      navLinks.classList.add('open');
+    });
+    closeBtn.addEventListener('click', () => {
+      navLinks.classList.remove('open');
+    });
+
+    if (portalBtn) {
+      portalBtn.addEventListener('click', () => {
+        if (portalPopup) {
+          portalPopup.style.display = 'flex';
+        }
+      });
+    }
+    if (popupClose) {
+      popupClose.addEventListener('click', () => {
+        if (portalPopup) {
+          portalPopup.style.display = 'none';
+        }
+      });
+    }
+
+    function checkHero() {
+      if (!hero) return;
+      if (window.scrollY > 50) {
+        hero.classList.add('shrink');
+      } else {
+        hero.classList.remove('shrink');
+      }
+    }
+
+    document.addEventListener('scroll', checkHero);
+    checkHero();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated privacy policy and terms of service pages with comprehensive legal copy and consistent site styling
- link the new legal pages from the primary navigation and footer across the site for easy access

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e3e4ca3ac883239b1bdb2c943be7a3