### PR TITLE
Move legal pages to new routes

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -514,8 +514,8 @@
           </div>
         </div>
       </li>
-      <li><a href="privacy.html">Privacy</a></li>
-      <li><a href="terms.html">Terms</a></li>
+      <li><a href="privacy-policy/">Privacy</a></li>
+      <li><a href="tos/">Terms</a></li>
     </ul>
     <button class="nav-right" id="investor-portal-btn">Investor Portal</button>
   </nav>
@@ -591,7 +591,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="terms.html">Terms of Service</a> | <a href="privacy.html">Privacy Policy</a>
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="tos/">Terms of Service</a> | <a href="privacy-policy/">Privacy Policy</a>
     </div>
   </footer>
   <script>

--- a/index.html
+++ b/index.html
@@ -587,8 +587,8 @@
           </div>
         </div>
       </li>
-      <li><a href="privacy.html">Privacy</a></li>
-      <li><a href="terms.html">Terms</a></li>
+      <li><a href="privacy-policy/">Privacy</a></li>
+      <li><a href="tos/">Terms</a></li>
     </ul>
     <button class="nav-right" id="investor-portal-btn">Investor Portal</button>
   </nav>
@@ -696,7 +696,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="terms.html">Terms of Service</a> | <a href="privacy.html">Privacy Policy</a>
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="tos/">Terms of Service</a> | <a href="privacy-policy/">Privacy Policy</a>
     </div>
   </footer>
   <script>

--- a/invest.html
+++ b/invest.html
@@ -514,8 +514,8 @@
           </div>
         </div>
       </li>
-      <li><a href="privacy.html">Privacy</a></li>
-      <li><a href="terms.html">Terms</a></li>
+      <li><a href="privacy-policy/">Privacy</a></li>
+      <li><a href="tos/">Terms</a></li>
     </ul>
     <button class="nav-right" id="investor-portal-btn">Investor Portal</button>
   </nav>
@@ -591,7 +591,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="terms.html">Terms of Service</a> | <a href="privacy.html">Privacy Policy</a>
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="tos/">Terms of Service</a> | <a href="privacy-policy/">Privacy Policy</a>
     </div>
   </footer>
   <script>

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -3,53 +3,53 @@
 <head>
   <meta charset="utf-8" />
   <title>Privacy Policy - Gouru</title>
-  <link rel="icon" type="image/png" href="logos/gouru_logo_png-favicon.png" />
+  <link rel="icon" type="image/png" href="../logos/gouru_logo_png-favicon.png" />
   <style>
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-Light.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-Light.otf') format('opentype');
       font-weight: 300;
       font-style: normal;
     }
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-LightItalic.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-LightItalic.otf') format('opentype');
       font-weight: 300;
       font-style: italic;
     }
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-Regular.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-Regular.otf') format('opentype');
       font-weight: 400;
       font-style: normal;
     }
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-Italic.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-Italic.otf') format('opentype');
       font-weight: 400;
       font-style: italic;
     }
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-Medium.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-Medium.otf') format('opentype');
       font-weight: 500;
       font-style: normal;
     }
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-MediumItalic.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-MediumItalic.otf') format('opentype');
       font-weight: 500;
       font-style: italic;
     }
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-Bold.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-Bold.otf') format('opentype');
       font-weight: 700;
       font-style: normal;
     }
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-BoldItalic.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-BoldItalic.otf') format('opentype');
       font-weight: 700;
       font-style: italic;
     }
@@ -226,7 +226,7 @@
       justify-content: center;
       text-align: center;
       color: #fff;
-      background: linear-gradient(135deg, rgba(11, 62, 91, 0.9), rgba(42, 157, 143, 0.85)), url('sample-image') center/cover no-repeat;
+      background: linear-gradient(135deg, rgba(11, 62, 91, 0.9), rgba(42, 157, 143, 0.85)), url('../sample-image') center/cover no-repeat;
       margin-bottom: 40px;
     }
     .hero .hero-text {
@@ -414,42 +414,42 @@
 </head>
 <body>
   <nav>
-    <div class="logo"><img src="logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img"> <span>Gouru</span>
+    <div class="logo"><img src="../logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img"> <span>Gouru</span>
     </div>
     <button class="hamburger">&#9776;</button>
     <ul class="nav-links">
       <li class="close-btn">&times;</li>
       <li class="dropdown">
-        <a href="invest.html">Invest With Us</a>
+        <a href="../invest.html">Invest With Us</a>
         <div class="dropdown-content invest-menu">
           <h3>Invest with us</h3>
           <div class="dropdown-sections">
             <div class="dropdown-col">
               <h4>About Us</h4>
-              <a href="index.html">Our Portfolio</a>
-              <a href="team.html">Our Team</a>
-              <a href="careers.html">Careers</a>
+              <a href="../index.html">Our Portfolio</a>
+              <a href="../team.html">Our Team</a>
+              <a href="../careers.html">Careers</a>
             </div>
             <div class="dropdown-col">
               <h4>Invest</h4>
-              <a href="invest.html">Investment Process</a>
+              <a href="../invest.html">Investment Process</a>
               <a href="#">Offerings</a>
               <a href="#">FAQ</a>
             </div>
             <div class="dropdown-col image-col">
-              <img src="sample-image" alt="Sample" />
+              <img src="../sample-image" alt="Sample" />
             </div>
           </div>
         </div>
       </li>
       <li class="dropdown">
-        <a href="sell.html">Sell to Us</a>
+        <a href="../sell.html">Sell to Us</a>
         <div class="dropdown-content sell-menu">
           <h3>Sell to us</h3>
           <div class="dropdown-sections">
             <div class="dropdown-col">
               <h4>Owners</h4>
-              <a href="sell.html">Selling Process</a>
+              <a href="../sell.html">Selling Process</a>
               <a href="#">Submit Property</a>
               <a href="#">FAQ</a>
             </div>
@@ -460,7 +460,7 @@
               <a href="#">Resources</a>
             </div>
             <div class="dropdown-col image-col">
-              <img src="sample-image" alt="Sample" />
+              <img src="../sample-image" alt="Sample" />
             </div>
           </div>
         </div>
@@ -472,8 +472,8 @@
           <div class="dropdown-sections">
             <div class="dropdown-col">
               <h4>About Us</h4>
-              <a href="team.html">Our Team</a>
-              <a href="careers.html">Careers</a>
+              <a href="../team.html">Our Team</a>
+              <a href="../careers.html">Careers</a>
               <a href="#">Contact Us</a>
             </div>
             <div class="dropdown-col">
@@ -481,13 +481,13 @@
               <p>To build communities through real estate innovation.</p>
             </div>
             <div class="dropdown-col image-col">
-              <img src="sample-image" alt="Sample" />
+              <img src="../sample-image" alt="Sample" />
             </div>
           </div>
         </div>
       </li>
-      <li><a href="privacy.html">Privacy</a></li>
-      <li><a href="terms.html">Terms</a></li>
+      <li><a href="../privacy-policy/">Privacy</a></li>
+      <li><a href="../tos/">Terms</a></li>
     </ul>
     <button class="nav-right" id="investor-portal-btn">Investor Portal</button>
   </nav>
@@ -577,15 +577,15 @@
     <div class="footer-top">
       <div class="footer-left">
         <div class="logo-group">
-          <img src="logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img" />
+          <img src="../logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img" />
           <span class="footer-logo-text">Gouru</span>
         </div>
         <p class="footer-copy">&copy; 2025 Gouru. All Rights Reserved.</p>
         <hr class="footer-divider" />
         <div class="social-icons">
-          <a href="https://linkedin.com/company/gouru"><img src="logos/linkedin.svg" alt="LinkedIn" /></a>
-          <a href="#"><img src="logos/instagram.svg" alt="Instagram" /></a>
-          <a href="#"><img src="logos/facebook.svg" alt="Facebook" /></a>
+          <a href="https://linkedin.com/company/gouru"><img src="../logos/linkedin.svg" alt="LinkedIn" /></a>
+          <a href="#"><img src="../logos/instagram.svg" alt="Instagram" /></a>
+          <a href="#"><img src="../logos/facebook.svg" alt="Facebook" /></a>
         </div>
         <div class="footer-attribution">
           <a href="https://www.vecteezy.com/free-photos/night" rel="nofollow">Night Stock photos by Vecteezy</a>
@@ -610,8 +610,8 @@
       <div class="footer-section">
         <h3>About Us</h3>
         <ul>
-          <li><a href="team.html">Our Team</a></li>
-          <li><a href="careers.html">Careers</a></li>
+          <li><a href="../team.html">Our Team</a></li>
+          <li><a href="../careers.html">Careers</a></li>
           <li><a href="#">Contact Us</a></li>
         </ul>
       </div>
@@ -624,7 +624,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="terms.html">Terms of Service</a> | <a href="privacy.html">Privacy Policy</a>
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="../tos/">Terms of Service</a> | <a href="../privacy-policy/">Privacy Policy</a>
     </div>
   </footer>
 

--- a/sell.html
+++ b/sell.html
@@ -514,8 +514,8 @@
           </div>
         </div>
       </li>
-      <li><a href="privacy.html">Privacy</a></li>
-      <li><a href="terms.html">Terms</a></li>
+      <li><a href="privacy-policy/">Privacy</a></li>
+      <li><a href="tos/">Terms</a></li>
     </ul>
     <button class="nav-right" id="investor-portal-btn">Investor Portal</button>
   </nav>
@@ -591,7 +591,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="terms.html">Terms of Service</a> | <a href="privacy.html">Privacy Policy</a>
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="tos/">Terms of Service</a> | <a href="privacy-policy/">Privacy Policy</a>
     </div>
   </footer>
   <script>

--- a/team.html
+++ b/team.html
@@ -514,8 +514,8 @@
           </div>
         </div>
       </li>
-      <li><a href="privacy.html">Privacy</a></li>
-      <li><a href="terms.html">Terms</a></li>
+      <li><a href="privacy-policy/">Privacy</a></li>
+      <li><a href="tos/">Terms</a></li>
     </ul>
     <button class="nav-right" id="investor-portal-btn">Investor Portal</button>
   </nav>
@@ -591,7 +591,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="terms.html">Terms of Service</a> | <a href="privacy.html">Privacy Policy</a>
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="tos/">Terms of Service</a> | <a href="privacy-policy/">Privacy Policy</a>
     </div>
   </footer>
   <script>

--- a/tos/index.html
+++ b/tos/index.html
@@ -3,53 +3,53 @@
 <head>
   <meta charset="utf-8" />
   <title>Terms of Service - Gouru</title>
-  <link rel="icon" type="image/png" href="logos/gouru_logo_png-favicon.png" />
+  <link rel="icon" type="image/png" href="../logos/gouru_logo_png-favicon.png" />
   <style>
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-Light.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-Light.otf') format('opentype');
       font-weight: 300;
       font-style: normal;
     }
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-LightItalic.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-LightItalic.otf') format('opentype');
       font-weight: 300;
       font-style: italic;
     }
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-Regular.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-Regular.otf') format('opentype');
       font-weight: 400;
       font-style: normal;
     }
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-Italic.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-Italic.otf') format('opentype');
       font-weight: 400;
       font-style: italic;
     }
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-Medium.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-Medium.otf') format('opentype');
       font-weight: 500;
       font-style: normal;
     }
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-MediumItalic.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-MediumItalic.otf') format('opentype');
       font-weight: 500;
       font-style: italic;
     }
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-Bold.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-Bold.otf') format('opentype');
       font-weight: 700;
       font-style: normal;
     }
     @font-face {
       font-family: 'Neue Montreal';
-      src: url('fonts/NeueMontreal-BoldItalic.otf') format('opentype');
+      src: url('../fonts/NeueMontreal-BoldItalic.otf') format('opentype');
       font-weight: 700;
       font-style: italic;
     }
@@ -226,7 +226,7 @@
       justify-content: center;
       text-align: center;
       color: #fff;
-      background: linear-gradient(135deg, rgba(11, 62, 91, 0.92), rgba(116, 139, 117, 0.85)), url('sample-image') center/cover no-repeat;
+      background: linear-gradient(135deg, rgba(11, 62, 91, 0.92), rgba(116, 139, 117, 0.85)), url('../sample-image') center/cover no-repeat;
       margin-bottom: 40px;
     }
     .hero .hero-text {
@@ -414,42 +414,42 @@
 </head>
 <body>
   <nav>
-    <div class="logo"><img src="logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img"> <span>Gouru</span>
+    <div class="logo"><img src="../logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img"> <span>Gouru</span>
     </div>
     <button class="hamburger">&#9776;</button>
     <ul class="nav-links">
       <li class="close-btn">&times;</li>
       <li class="dropdown">
-        <a href="invest.html">Invest With Us</a>
+        <a href="../invest.html">Invest With Us</a>
         <div class="dropdown-content invest-menu">
           <h3>Invest with us</h3>
           <div class="dropdown-sections">
             <div class="dropdown-col">
               <h4>About Us</h4>
-              <a href="index.html">Our Portfolio</a>
-              <a href="team.html">Our Team</a>
-              <a href="careers.html">Careers</a>
+              <a href="../index.html">Our Portfolio</a>
+              <a href="../team.html">Our Team</a>
+              <a href="../careers.html">Careers</a>
             </div>
             <div class="dropdown-col">
               <h4>Invest</h4>
-              <a href="invest.html">Investment Process</a>
+              <a href="../invest.html">Investment Process</a>
               <a href="#">Offerings</a>
               <a href="#">FAQ</a>
             </div>
             <div class="dropdown-col image-col">
-              <img src="sample-image" alt="Sample" />
+              <img src="../sample-image" alt="Sample" />
             </div>
           </div>
         </div>
       </li>
       <li class="dropdown">
-        <a href="sell.html">Sell to Us</a>
+        <a href="../sell.html">Sell to Us</a>
         <div class="dropdown-content sell-menu">
           <h3>Sell to us</h3>
           <div class="dropdown-sections">
             <div class="dropdown-col">
               <h4>Owners</h4>
-              <a href="sell.html">Selling Process</a>
+              <a href="../sell.html">Selling Process</a>
               <a href="#">Submit Property</a>
               <a href="#">FAQ</a>
             </div>
@@ -460,7 +460,7 @@
               <a href="#">Resources</a>
             </div>
             <div class="dropdown-col image-col">
-              <img src="sample-image" alt="Sample" />
+              <img src="../sample-image" alt="Sample" />
             </div>
           </div>
         </div>
@@ -472,8 +472,8 @@
           <div class="dropdown-sections">
             <div class="dropdown-col">
               <h4>About Us</h4>
-              <a href="team.html">Our Team</a>
-              <a href="careers.html">Careers</a>
+              <a href="../team.html">Our Team</a>
+              <a href="../careers.html">Careers</a>
               <a href="#">Contact Us</a>
             </div>
             <div class="dropdown-col">
@@ -481,13 +481,13 @@
               <p>To build communities through real estate innovation.</p>
             </div>
             <div class="dropdown-col image-col">
-              <img src="sample-image" alt="Sample" />
+              <img src="../sample-image" alt="Sample" />
             </div>
           </div>
         </div>
       </li>
-      <li><a href="privacy.html">Privacy</a></li>
-      <li><a href="terms.html">Terms</a></li>
+      <li><a href="../privacy-policy/">Privacy</a></li>
+      <li><a href="../tos/">Terms</a></li>
     </ul>
     <button class="nav-right" id="investor-portal-btn">Investor Portal</button>
   </nav>
@@ -585,15 +585,15 @@
     <div class="footer-top">
       <div class="footer-left">
         <div class="logo-group">
-          <img src="logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img" />
+          <img src="../logos/gouru_logo_no_bg.png" alt="Gouru logo" class="logo-img" />
           <span class="footer-logo-text">Gouru</span>
         </div>
         <p class="footer-copy">&copy; 2025 Gouru. All Rights Reserved.</p>
         <hr class="footer-divider" />
         <div class="social-icons">
-          <a href="https://linkedin.com/company/gouru"><img src="logos/linkedin.svg" alt="LinkedIn" /></a>
-          <a href="#"><img src="logos/instagram.svg" alt="Instagram" /></a>
-          <a href="#"><img src="logos/facebook.svg" alt="Facebook" /></a>
+          <a href="https://linkedin.com/company/gouru"><img src="../logos/linkedin.svg" alt="LinkedIn" /></a>
+          <a href="#"><img src="../logos/instagram.svg" alt="Instagram" /></a>
+          <a href="#"><img src="../logos/facebook.svg" alt="Facebook" /></a>
         </div>
         <div class="footer-attribution">
           <a href="https://www.vecteezy.com/free-photos/night" rel="nofollow">Night Stock photos by Vecteezy</a>
@@ -618,8 +618,8 @@
       <div class="footer-section">
         <h3>About Us</h3>
         <ul>
-          <li><a href="team.html">Our Team</a></li>
-          <li><a href="careers.html">Careers</a></li>
+          <li><a href="../team.html">Our Team</a></li>
+          <li><a href="../careers.html">Careers</a></li>
           <li><a href="#">Contact Us</a></li>
         </ul>
       </div>
@@ -632,7 +632,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="terms.html">Terms of Service</a> | <a href="privacy.html">Privacy Policy</a>
+      <a href="https://gouru.org">gouru.org</a> | <a href="https://gouru.foundation">gouru.foundation</a> | <a href="../tos/">Terms of Service</a> | <a href="../privacy-policy/">Privacy Policy</a>
     </div>
   </footer>
 


### PR DESCRIPTION
## Summary
- move the terms of service and privacy policy pages into new `/tos/` and `/privacy-policy/` directories with updated asset references
- update navigation and footer links across the site to point to the new legal routes

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e3f49f88648323be895c8d3803a420